### PR TITLE
docs: align document type references with JSON config

### DIFF
--- a/document_processing/__init__.py
+++ b/document_processing/__init__.py
@@ -1,8 +1,7 @@
-"""
-Document processing package.
+"""Document processing package.
 
 This package exposes functions to classify and extract structured data from
-documents.  See `doc_classifier`, `doc_extractor` and `pipeline` for more
+documents. See ``doc_classifier``, ``doc_extractor`` and ``pipeline`` for more
 details.
 """
 

--- a/document_processing/agents.py
+++ b/document_processing/agents.py
@@ -7,7 +7,7 @@ CrewAI-based agents for document classification and extraction.
 This module defines thin wrappers around CrewAI agents to:
 
 1) Classify document OCR text into a known type defined in
-   ``config/doc_types.yaml``.
+   ``config/doc_types.json``.
 2) Extract structured fields according to type-specific instructions.
 
 These helpers gracefully fall back to the existing LangChain-only

--- a/document_processing/doc_classifier.py
+++ b/document_processing/doc_classifier.py
@@ -6,11 +6,11 @@ This module provides a function to classify a piece of text into one of
 several predefined document types.  It leverages a large language model
 from OpenAI via LangChain to perform the classification, returning both
 the predicted type and a confidence score.  The available document types
-and their extraction instructions are defined in ``config/doc_types.yaml``.
+and their extraction instructions are defined in ``config/doc_types.json``.
 
 The classifier exposes two utilities:
 
-* ``load_doc_types`` reads the YAML configuration file and returns a
+* ``load_doc_types`` reads the JSON configuration file and returns a
   mapping of document type keys to descriptions and instructions.
 * ``classify_document`` sends the document text to an LLM and asks it to
   choose the most appropriate type from the allowed list.  The result is
@@ -54,7 +54,7 @@ __all__ = [
 
 class DocumentType(str, Enum):
     """Enumeration of supported document types.  The member names must
-    match the keys defined in ``doc_types.yaml``.
+    match the keys defined in ``doc_types.json``.
     """
 
     INVOICE = "invoice"
@@ -74,11 +74,11 @@ class ClassificationResult(BaseModel):
 
 
 def load_doc_types(config_path: Optional[Path] = None) -> Dict[str, Dict[str, str]]:
-    """Load the document types configuration from a YAML file.
+    """Load the document types configuration from a JSON file.
 
     Args:
-        config_path: Optional path to the YAML config.  If omitted it
-            defaults to ``document_processing/config/doc_types.yaml`` relative
+        config_path: Optional path to the JSON config.  If omitted it
+            defaults to ``document_processing/config/doc_types.json`` relative
             to this module.
 
     Returns:


### PR DESCRIPTION
## Summary
- clarify document type configuration uses `doc_types.json`
- fix top-level package docstring

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2b64a32f8832d9996065f30fab1aa